### PR TITLE
Faster bounty selection

### DIFF
--- a/src/components/SelectableBounty.jsx
+++ b/src/components/SelectableBounty.jsx
@@ -60,16 +60,26 @@ const SelectableBounty = ({
     return null;
   }
 
+  const handleBountyClick = (e) => {
+    if (e.type === "click") {
+      if (count === 0) {
+        setCount(bountyKey, 1);
+      } else {
+        setCount(bountyKey, count + 1);
+      }
+    } else if (e.type === "contextmenu") {
+      e.preventDefault();
+      if (count > 0) {
+        setCount(bountyKey, count - 1);
+      }
+    }
+  };
+
   return (
     <div
       className={`cursor-pointer group relative w-full min-h-[60px] border dark:border-zinc-700 dark:text-zinc-200 p-2 rounded block hover:text-blue-500 dark:hover:text-white hover:bg-gray-50 dark:hover:bg-zinc-800 select-none`}
-      onClick={() => {
-        if (count === 0) {
-          setCount(bountyKey, 1);
-        } else {
-          setCount(bountyKey, 0);
-        }
-      }}
+      onClick={handleBountyClick}
+      onContextMenu={handleBountyClick}
     >
       <div className="flex items-center h-full text-right">
         <img

--- a/src/components/SelectableBounty.jsx
+++ b/src/components/SelectableBounty.jsx
@@ -62,7 +62,7 @@ const SelectableBounty = ({
 
   const handleBountyClick = (e) => {
     if (e.type === "click") {
-      if (count === 0) {
+      if (count === 0 || !canSelectMoreThanOne) {
         setCount(bountyKey, 1);
       } else {
         setCount(bountyKey, count + 1);

--- a/src/pages/SelectBounties.jsx
+++ b/src/pages/SelectBounties.jsx
@@ -33,15 +33,13 @@ const SelectBounties = () => {
     >
       <Subheading>Your bounties</Subheading>
       <Paragraph className="mb-2 dark:text-zinc-300">
-        Select bounties you currently have{" "}
-        <span className="font-bold">(up to 6 total).</span> To see or hide
-        relevant bounties, change your merchanting level on the{" "}
-        <InternalLink to="/configuration">configuration page</InternalLink>. Not
-        all bounties have been discovered yet, so higher level ones may be
-        missing. Please help contribute by providing details about these
-        bounties in our{" "}
-        <ExternalLink to="https://discord.gg/fcSYv9GPwJ">Discord</ExternalLink>,
-        and we will get them added.
+        Select bounties you currently have <span className="font-bold">(up to 6 total).</span> To see or hide relevant bounties, change your merchanting level
+        on the <InternalLink to="/configuration">configuration page</InternalLink>. Left click to increase the count, right click to decrease the count.
+      </Paragraph>
+      <Paragraph className="mb-2 dark:text-zinc-300">
+        {" "}
+        Not all bounties have been discovered yet, so higher level ones may be missing. Please help contribute by providing details about these bounties in our{" "}
+        <ExternalLink to="https://discord.gg/fcSYv9GPwJ">Discord</ExternalLink>, and we will get them added.
       </Paragraph>
       <button
         className={`text-blue-600 dark:text-blue-500 hover:underline font-medium text-sm mb-3 ${selectedBountiesCount === 0 ? "invisible" : ""}`}


### PR DESCRIPTION
Resolves this suggestion: https://discord.com/channels/1307880800901136404/1313324260629938216

New behavior: On left click, add/increment the bounty count. On right click, remove/decrement the bounty count. Bounties in the Bounty Board section with `!canSelectMoreThanOne` cannot increment beyond 1 so current behavior is retained. Legacy up/down button behavior is retained.